### PR TITLE
Recursively Extract Cards

### DIFF
--- a/config/apply/ccsm/prefetch.js
+++ b/config/apply/ccsm/prefetch.js
@@ -1,6 +1,6 @@
 export const prefetch = {
   "Patient": "Patient/{{context.patientId}}",
-  "ObservationCore": "Observation?patient={{context.patientId}}&category=core+characteristics",
+  "ObservationCore": "Observation?patient={{context.patientId}}&category=core-characteristics",
   "ObservationLab": "Observation?patient={{context.patientId}}&category=laboratory",
   "ObservationLabor": "Observation?patient={{context.patientId}}&category=labor-delivery",
   "ObservationObGyn": "Observation?patient={{context.patientId}}&category=obstetrics-gynecology",

--- a/config/apply/ccsm/prefetch.js
+++ b/config/apply/ccsm/prefetch.js
@@ -1,15 +1,15 @@
 export const prefetch = {
-  "Patient": "Patient/{{context.patientId}}",
-  "ObservationCore": "Observation?patient={{context.patientId}}&category=core-characteristics",
-  "ObservationLab": "Observation?patient={{context.patientId}}&category=laboratory",
-  "ObservationLabor": "Observation?patient={{context.patientId}}&category=labor-delivery",
-  "ObservationObGyn": "Observation?patient={{context.patientId}}&category=obstetrics-gynecology",
-  "ObservationSmart": "Observation?patient={{context.patientId}}&category=smartdata",
-  "Condition": "Condition?patient={{context.patientId}}",
-  "ConditionProblem": "Condition?patient={{context.patientId}}&category=problem-list-item&clinical-status=active",
-  "MedicationRequest": "MedicationRequest?patient={{context.patientId}}",
-  "Procedure": "Procedure?patient={{context.patientId}}",
-  "DiagnosticReport": "DiagnosticReport?patient={{context.patientId}}",
-  "Encounter": "Encounter?patient={{context.patientId}}",
-  "Immunization": "Immunization?patient={{context.patientId}}"
+  'Patient': 'Patient/{{context.patientId}}',
+  'ObservationCore': 'Observation?patient={{context.patientId}}&category=core-characteristics',
+  'ObservationLab': 'Observation?patient={{context.patientId}}&category=laboratory',
+  'ObservationLabor': 'Observation?patient={{context.patientId}}&category=labor-delivery',
+  'ObservationObGyn': 'Observation?patient={{context.patientId}}&category=obstetrics-gynecology',
+  'ObservationSmart': 'Observation?patient={{context.patientId}}&category=smartdata',
+  'Condition': 'Condition?patient={{context.patientId}}',
+  'ConditionProblem': 'Condition?patient={{context.patientId}}&category=problem-list-item&clinical-status=active',
+  'MedicationRequest': 'MedicationRequest?patient={{context.patientId}}',
+  'Procedure': 'Procedure?patient={{context.patientId}}',
+  'DiagnosticReport': 'DiagnosticReport?patient={{context.patientId}}',
+  'Encounter': 'Encounter?patient={{context.patientId}}',
+  'Immunization': 'Immunization?patient={{context.patientId}}'
 };

--- a/routes/cds-services.js
+++ b/routes/cds-services.js
@@ -226,6 +226,32 @@ async function call(req, res, next) {
     };
     const [RequestGroup, ...otherResources] = await applyAndMerge(planDefinition, patientReference, resolver, aux);
     resolver = simpleResolver([...otherResources], true);
+    
+    
+    // If RequestGroup has an action
+    if (RequestGroup?.action) {
+  
+      // Pass action array into extractCards recursive function
+      let newCards = extractCards(RequestGroup.action, resolver);
+      
+      // For each action in the array
+
+      // If action.resource.reference contains a CommunicationRequest
+      // Make an information card with that action (pass into extractInformation)
+
+      // If action.selection behavior exists
+      // Make a suggestion card with the kids as suggestions (pass kids into extractSuggetsions)
+      // If they are a Service Request, add a suggestion with an action with a resource
+
+      // Else if action exists, call Extract card on the action
+
+      // Return all types of cards and then add them to the cards array
+      
+      // Communication request - create a new card where the detail on the card becomes a payload
+      // If you see an action with selection behavior, each of those are suggestions with a card
+    
+    }
+
     for (const action of RequestGroup.action[0].action) {
       let sources = action?.documentation ? getSources(action.documentation) : [];
       let card = {
@@ -485,6 +511,33 @@ function getSources(relatedArtifacts) {
     }
   }
   return sources;
+}
+
+function extractCards(actions, resolver) {
+
+  // For each action in the array
+  for (const action of actions) {
+
+    // If action.resource.reference contains a CommunicationRequest
+    if (action.resource?.reference && action.resource?.reference.includes('CommunicationRequest')) {
+    
+      // Make an information card with that action (pass into extractInformation)
+
+    // If action.selection behavior exists
+    } else if (action.selectionBehavior) {
+
+      // Make a suggestion card with the kids as suggestions (pass kids into extractSuggetsions)
+      // If they are a Service Request, add a suggestion with an action with a resource
+
+    // Else if sub-action exists, call Extract card on the action
+    } else if (action.action) {
+      extractCards(action.action);
+    }
+
+    // Return all types of cards
+
+  }
+
 }
 
 function extractSuggestions(actions, otherResources) {

--- a/routes/cds-services.js
+++ b/routes/cds-services.js
@@ -231,19 +231,20 @@ async function call(req, res, next) {
       let card = {
         summary: action.title,
         detail: action.description,
+        uuid: Math.floor(100000 + Math.random() * 900000), // Cards must have a uuid for suggestions to render properly
         indicator: getIndicator(action.priority),
         source: sources.slice(0,1),
         selectionBehavior: action.selectionBehavior,
-        suggestion: action.action ? extractSuggestions(action.action, otherResources) : 
-          {
+        suggestions: action.action ? extractSuggestions(action.action, otherResources) : 
+          [{
             label: action.title,
             uuid: action.id,
-            actions: {
+            actions: [{
               type: 'create',
               description: action.description ?? action.title,
               resource: action?.resource?.reference ? resolver(action.resource.reference)[0] : null
-            }
-          },
+            }]
+          }],
         links: sources.slice(1)?.map(s => ({...s,type:'absolute'}))
       };     
       cards.push(card);
@@ -256,7 +257,7 @@ async function call(req, res, next) {
     console.log('--------------------------------------------------');
     console.log('Suggestions:');
     cards.forEach(card => {
-      console.log(card.suggestion);
+      console.log(card.suggestions);
     });
     console.log();
     
@@ -494,18 +495,11 @@ function extractSuggestions(actions, otherResources) {
       label: action.title,
       uuid: action.id,
       actions: action?.action ? extractSubactions(action.action, resolver) :
-        {
+        [{
           type: action?.type ?? 'create',
           description: action?.description,
           resource: action?.resource?.reference ? resolver(action.resource.reference)[0] : null,
-        }
-      // resource: action?.resource?.reference ? 
-      //   [{
-      //     type: 'create',
-      //     description: action.description,
-      //     resource: resolver(action.resource.reference)[0],
-      //   }] : 
-      //   []
+        }]
     });
   }
   return suggestions;

--- a/routes/cds-services.js
+++ b/routes/cds-services.js
@@ -518,10 +518,13 @@ function extractCards(actions, resolver) {
   // For each action in the array
   for (const action of actions) {
 
+    let cards = [];
+
     // If action.resource.reference contains a CommunicationRequest
     if (action.resource?.reference && action.resource?.reference.includes('CommunicationRequest')) {
     
       // Make an information card with that action (pass into extractInformation)
+      cards.push(extractInformation(action));
 
     // If action.selection behavior exists
     } else if (action.selectionBehavior) {
@@ -539,6 +542,33 @@ function extractCards(actions, resolver) {
   }
 
 }
+
+function extractInformation(action, resolver) {
+
+  let sources = action?.documentation ? getSources(action.documentation) : [];
+  let card = {
+    summary: action.title,
+    detail: action.description,
+    uuid: Math.floor(100000 + Math.random() * 900000), // Cards must have a uuid for suggestions to render properly
+    indicator: getIndicator(action.priority),
+    source: sources.slice(0,1),
+    selectionBehavior: action.selectionBehavior,
+    suggestions: action.action ? extractSuggestions(action.action, otherResources) : 
+      [{
+        label: action.title,
+        uuid: action.id,
+        actions: [{
+          type: 'create',
+          description: action.description ?? action.title,
+          resource: action?.resource?.reference ? resolver(action.resource.reference)[0] : null
+        }]
+      }],
+    links: sources.slice(1)?.map(s => ({...s,type:'absolute'}))
+  };     
+  // cards.push(card);
+
+}
+
 
 function extractSuggestions(actions, otherResources) {
   let resolver = simpleResolver([...otherResources], true);

--- a/routes/cds-services.js
+++ b/routes/cds-services.js
@@ -232,32 +232,7 @@ async function call(req, res, next) {
       // Pass action array into extractCards recursive function
       let newCards = extractCards(RequestGroup.action, otherResources).flat();
       cards.push(...newCards);
-      console.log('Final cards', cards);
     }
-
-    // for (const action of RequestGroup.action[0].action) {
-    //   let sources = action?.documentation ? getSources(action.documentation) : [];
-    //   let card = {
-    //     summary: action.title,
-    //     detail: action.description,
-    //     uuid: Math.floor(100000 + Math.random() * 900000), // Cards must have a uuid for suggestions to render properly
-    //     indicator: getIndicator(action.priority),
-    //     source: sources.slice(0,1),
-    //     selectionBehavior: action.selectionBehavior,
-    //     suggestions: action.action ? extractSuggestions(action.action, otherResources) : 
-    //       [{
-    //         label: action.title,
-    //         uuid: action.id,
-    //         actions: [{
-    //           type: 'create',
-    //           description: action.description ?? action.title,
-    //           resource: action?.resource?.reference ? resolver(action.resource.reference)[0] : null
-    //         }]
-    //       }],
-    //     links: sources.slice(1)?.map(s => ({...s,type:'absolute'}))
-    //   };     
-    //   cards.push(card);
-    // }
 
     console.log('--------------------------------------------------');
     console.log('Cards returned from CDS:');
@@ -497,25 +472,19 @@ function getSources(relatedArtifacts) {
 }
 
 function extractCards(actions, otherResources) {
-
   let cards = [];
   // For each action in the array
   for (const action of actions) {
-
     // If action.resource.reference contains a CommunicationRequest
     if (action.resource?.reference && action.resource?.reference?.includes('CommunicationRequest')) {
-    
       // Make an information card with that action (pass into extractInformation)
       cards.push(extractInformation(action, otherResources));
-
     // If action.selection behavior exists
     } else if (action.selectionBehavior) {
-
-      // Make a suggestion card with the kids as suggestions (pass kids into extractSuggetsions)
-      // If they are a Service Request, add a suggestion with an action with a resource
+      // Make a suggestion card with the children actions as suggestions (pass children into extractSuggetsions)
+      // If child action is a Service Request, add a suggestion with an action with a resource
       cards.push(extractSuggestions(action, otherResources));
-
-    // Else if sub-action exists, call Extract card on the action
+    // Else if sub-action exists, call extractCard on the sub-action
     } else if (action.action) {
       cards.push(extractCards(action.action, otherResources));
     }
@@ -542,7 +511,6 @@ function extractSuggestions(action, otherResources) {
   let resolver = simpleResolver([...otherResources], true);
   let sources = action?.documentation ? getSources(action.documentation) : [];
   let suggestions = [];
-
   for (const subaction of action.action) {
     if (subaction.resource?.reference?.includes('ServiceRequest')) {
       let suggestion = {
@@ -572,35 +540,5 @@ function extractSuggestions(action, otherResources) {
   };   
   return card;  
 }
-
-// function extractSuggestions(actions, otherResources) {
-//   let resolver = simpleResolver([...otherResources], true);
-//   let suggestions = [];
-//   for (const action of actions) {
-//     suggestions.push({
-//       label: action.title,
-//       uuid: action.id,
-//       actions: action?.action ? extractSubactions(action.action, resolver) :
-//         [{
-//           type: action?.type ?? 'create',
-//           description: action?.description,
-//           resource: action?.resource?.reference ? resolver(action.resource.reference)[0] : null,
-//         }]
-//     });
-//   }
-//   return suggestions;
-// }
-
-// function extractSubactions(actionAction, resolver) {
-//   let subactions = [];
-//   for (const a2 of actionAction) {
-//     subactions.push({
-//       type: 'create',
-//       description: a2.description ?? a2.title,
-//       resource: a2?.resource?.reference ? resolver(a2.resource.reference)[0] : null
-//     });
-//   }
-//   return subactions;
-// }
 
 export default router;

--- a/routes/cds-services.js
+++ b/routes/cds-services.js
@@ -225,10 +225,8 @@ async function call(req, res, next) {
       valueSetJson
     };
     const [RequestGroup, ...otherResources] = await applyAndMerge(planDefinition, patientReference, resolver, aux);
-    
     // If RequestGroup has an action
     if (RequestGroup?.action) {
-  
       // Pass action array into extractCards recursive function
       let newCards = extractCards(RequestGroup.action, otherResources).flat();
       cards.push(...newCards);
@@ -497,7 +495,7 @@ function extractInformation(action, otherResources) {
   let sources = action?.documentation ? getSources(action.documentation) : [];
   let card = {
     summary: action.title,
-    uuid: action.id, // Cards must have a uuid for cards to render properly
+    uuid: action.id, // Cards must have a uuid to render properly
     indicator: getIndicator(action.priority),
     source: sources.slice(0,1),
     links: sources.slice(1)?.map(s => ({...s,type:'absolute'})),
@@ -530,7 +528,7 @@ function extractSuggestions(action, otherResources) {
   let card = {
     summary: action.title,
     detail: action.description,
-    uuid: action.id, // Cards must have a uuid for suggestions to render properly
+    uuid: action.id, // Cards must have a uuid to render properly
     indicator: getIndicator(action.priority),
     source: sources.slice(0,1),
     selectionBehavior: action.selectionBehavior,

--- a/routes/cds-services.js
+++ b/routes/cds-services.js
@@ -147,7 +147,7 @@ async function call(req, res, next) {
 
   // Clean prefetch before logging
   let body = cloneDeep(req?.body);
-  Object.entries(body.prefetch).forEach(([key,value]) => {
+  Object.entries(req?.body?.prefetch ?? {}).forEach(([key,value]) => {
     if (value?.resourceType !== 'Bundle') {
       body.prefetch[key] = {
         id: value.id,
@@ -469,8 +469,7 @@ function getSources(relatedArtifacts) {
   return sources;
 }
 
-function extractCards(actions, otherResources) {
-  let cards = [];
+function extractCards(actions, otherResources, cards=[]) {
   // For each action in the array
   for (const action of actions) {
     // If action.resource.reference contains a CommunicationRequest
@@ -484,7 +483,7 @@ function extractCards(actions, otherResources) {
       cards.push(extractSuggestions(action, otherResources));
     // Else if sub-action exists, call extractCard on the sub-action
     } else if (action.action) {
-      cards.push(extractCards(action.action, otherResources));
+      cards = extractCards(action.action, otherResources, cards);
     }
   }
   return cards;


### PR DESCRIPTION
Change the way that a Request Group is mapped to a CDS Hooks card by recursively walking through the Request Group's actions and:
- Creating an information card if an action contains a CommunicationRequest resource
- Creating a suggestion card if an action contains selection behavior. Any sub-actions that reference ServiceRequest resources get added to the card as suggestions.


This PR also fixes a typo in the category parameter for the Observation (Core Characteristics) prefetch value.

You can see the following 2 information cards and 1 suggestion card when this branch of cds-services is reached from the [open CDS Hooks Sandbox](https://sandbox.cds-hooks.org/):

<img width="783" alt="Information and Suggestion Cards - Recurive Building" src="https://user-images.githubusercontent.com/51176978/206396674-1c21d53d-dbbf-4eed-ac85-7eb5040fbb13.png">
