### PR TITLE
Return "(no date available)" for a resource without a date element instead of "null"

### DIFF
--- a/config/apply/ccsm/collapse.js
+++ b/config/apply/ccsm/collapse.js
@@ -155,7 +155,8 @@ export function collapseIntoOne(cards, useHtml=false) {
 }
 
 function formatEntry(ent) {
-  let entString = ent.name + ' (' + ent.date + '): ';
+  let entDate = ent.date ?? 'no date available';
+  let entString = ent.name + ' (' + entDate + '): ';
   entString = ent.value ? entString + ent.value : entString + 'No result available';
   return entString;
 }


### PR DESCRIPTION
Currently if no date element is present in a dashboard resource, the Patient History portion of the CDS Hooks card will list the name of the clinical event, followed by "(null)". This makes it clear to the clinician that no date information was available.