### PR TITLE
Add newline spacing after recommendations that are hard-coded into CDS Hooks app

### DIFF
--- a/config/apply/ccsm/collapse.js
+++ b/config/apply/ccsm/collapse.js
@@ -18,7 +18,7 @@ export function collapseIntoOne(cards, useHtml=false) {
     justOneCard = [{
       ...errors[0],
       summary,
-      detail: details.join('\n') ?? 'The CDS has encountered an error.'
+      detail: details.join('\n') ?? 'The CDS has encountered an error.' + '\n\n'
     }];
   } else if (decisionAids.length > 0) {
     // Try to deserialize the decision aids
@@ -56,7 +56,7 @@ export function collapseIntoOne(cards, useHtml=false) {
         label: 'no source listed'
       },
       links: [],
-      detail: 'No recommendation has been returned by the CDS.'
+      detail: 'No recommendation has been returned by the CDS.'  + '\n\n'
     }];
   }
 

--- a/config/apply/ccsm/collapse.js
+++ b/config/apply/ccsm/collapse.js
@@ -155,7 +155,8 @@ export function collapseIntoOne(cards, useHtml=false) {
 }
 
 function formatEntry(ent) {
-  let entString = ent.name + ' (' + ent.date + '): ';
+  let entDate = ent.date ?? 'no date available';
+  let entString = ent.name + ' (' + entDate + '): ';
   entString = ent.value ? entString + ent.value : entString + 'No result available';
   return entString;
 }

--- a/config/apply/ccsm/collapse.js
+++ b/config/apply/ccsm/collapse.js
@@ -18,7 +18,7 @@ export function collapseIntoOne(cards, useHtml=false) {
     justOneCard = [{
       ...errors[0],
       summary,
-      detail: details.join('\n') ?? 'The CDS has encountered an error.' + '\n\n'
+      detail: details.join('\n') ?? 'The CDS has encountered an error.\n\n'
     }];
   } else if (decisionAids.length > 0) {
     // Try to deserialize the decision aids
@@ -56,7 +56,7 @@ export function collapseIntoOne(cards, useHtml=false) {
         label: 'no source listed'
       },
       links: [],
-      detail: 'No recommendation has been returned by the CDS.'  + '\n\n'
+      detail: 'No recommendation has been returned by the CDS.\n\n'
     }];
   }
 


### PR DESCRIPTION
The "No recommendation has been returned by the CDS," and "the CDS has encountered an error," are both error handling recommendations that are hard-coded into the CDS app itself. The normal recommendations are rendered with newline spacing after them, however, these recommendations did not including the newline spacing, which was causing an issue where the next section of the text returned in the CDS Hooks (the "Patient:...." header ) would not render properly, since it was not on it's own line.