### PR TITLE
Map ECC HSIL result to CIN 3, rather than HSIL, Unspecified.

### DIFF
--- a/config/apply/ccsm/translate.js
+++ b/config/apply/ccsm/translate.js
@@ -269,7 +269,7 @@ const customEccCodes = {
   },
   'ECT.14015.3': {
     Value: 'HSIL',
-    mapping: 'HSIL, Unspecified'
+    mapping: 'CIN 3'
   },
   'ECT.14015.4': {
     Value: 'AIS',


### PR DESCRIPTION
See https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/issues/95 and https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/issues/97, which describe how the mapping of ECC HSIL needs to be changed from "HSIL, Unspecified", to Histologic CIN3.