### PR TITLE
Map Excision Results

### DIFF
--- a/config/apply/ccsm/translate.js
+++ b/config/apply/ccsm/translate.js
@@ -245,6 +245,64 @@ const customHistologyCodes = {
   }
 };
 
+// ## ExcisionResults
+// >Can be null.
+
+// Maps to category values in ECT, 14006 - CCS - TRANSCRIBED EXCISION RESULTS
+
+// ECT.14006.1 - Normal
+// ECT.14006.3 - CIN1
+// ECT.14006.4 - CIN2
+// ECT.14006.5 - CIN3
+// ECT.14006.6 - AIS
+// ECT.14006.10 - Squamous Cell Carcinoma
+// ECT.14006.11 - Adenocarcinoma
+// ECT.14006.12 - Margins Negative
+// ECT.14006.13 - Margins Positive
+// ECT.14006.99 - Other
+const customExcisionCodes = {
+  'ECT.14006.1': {
+    Value: 'Normal',
+    mapping: null
+  },
+  'ECT.14006.3': {
+    Value: 'CIN1',
+    mapping: null
+  },
+  'ECT.14006.4': {
+    Value: 'CIN2',
+    mapping: null
+  },
+  'ECT.14006.5': {
+    Value: 'CIN3',
+    mapping: null
+  },
+  'ECT.14006.6': {
+    Value: 'AIS',
+    mapping: 'AIS'
+  },
+  'ECT.14006.10': {
+    Value: 'Squamous Cell Carcinoma',
+    mapping: 'Cancer'
+  },
+  'ECT.14006.11': {
+    Value: 'Adenocarcinoma',
+    mapping: 'Cancer'
+  },
+  'ECT.14006.12': {
+    Value: 'Margins Negative',
+    mapping: null
+  },
+  'ECT.14006.13': {
+    Value: 'Margins Positive',
+    mapping: null
+  },
+  'ECT.14006.99': {
+    Value: 'Other',
+    mapping: null
+  }
+};
+
 // ## EndocervicalCuretageResults
 // >Can be null.
 
@@ -332,6 +390,7 @@ export function translateResponse(customApiResponse, patientData) {
       PapResults: papResults,
       HPVResults: hpvResults,
       ColposcopyResults: colposcopyResults,
+      ExcisionResults: excisionResults,
       EndocervicalCuretageResults: endocervicalCuretageResults
     } = order;
 
@@ -350,7 +409,12 @@ export function translateResponse(customApiResponse, patientData) {
     if (hpvResults.length > 0) {
       codings.push(standardTestTypeCodes['HPV']);
     }
-    if ((colposcopyResults.length > 0) || (endocervicalCuretageResults.length > 0)) {
+    let ExcisionResultsShowAisOrCancer = 
+      excisionResults.some(r => {
+        const AisOrCancerCodes = ['ECT.14006.6', 'ECT.14006.10', 'ECT.14006.11'];
+        return AisOrCancerCodes.includes(r.ID);
+      });
+    if ((colposcopyResults.length > 0) || (endocervicalCuretageResults.length > 0) || (excisionResults.length > 0 && ExcisionResultsShowAisOrCancer)) {
       codings.push(standardTestTypeCodes['Cervical Histology']);
     }
 
@@ -376,6 +440,11 @@ export function translateResponse(customApiResponse, patientData) {
 
     // Map the custom ECC results to our standard codes
     conclusionCodes = mapResults(endocervicalCuretageResults, customEccCodes, standardHistologyCodes, conclusionCodes);
+
+    // Map the custom excision results to our standard codes
+    if (ExcisionResultsShowAisOrCancer) {
+      conclusionCodes = mapResults(excisionResults, customExcisionCodes, standardHistologyCodes, conclusionCodes);
+    }
 
     if (diagnosticReportIndex !== -1) {
       console.log('Found the diagnostic report reference');

--- a/config/apply/ccsm/translate.js
+++ b/config/apply/ccsm/translate.js
@@ -261,22 +261,6 @@ const customHistologyCodes = {
 // ECT.14006.13 - Margins Positive
 // ECT.14006.99 - Other
 const customExcisionCodes = {
-  'ECT.14006.1': {
-    Value: 'Normal',
-    mapping: null
-  },
-  'ECT.14006.3': {
-    Value: 'CIN1',
-    mapping: null
-  },
-  'ECT.14006.4': {
-    Value: 'CIN2',
-    mapping: null
-  },
-  'ECT.14006.5': {
-    Value: 'CIN3',
-    mapping: null
-  },
   'ECT.14006.6': {
     Value: 'AIS',
     mapping: 'AIS'
@@ -288,18 +272,6 @@ const customExcisionCodes = {
   'ECT.14006.11': {
     Value: 'Adenocarcinoma',
     mapping: 'Cancer'
-  },
-  'ECT.14006.12': {
-    Value: 'Margins Negative',
-    mapping: null
-  },
-  'ECT.14006.13': {
-    Value: 'Margins Positive',
-    mapping: null
-  },
-  'ECT.14006.99': {
-    Value: 'Other',
-    mapping: null
   }
 };
 
@@ -411,7 +383,7 @@ export function translateResponse(customApiResponse, patientData) {
     }
     let ExcisionResultsShowAisOrCancer = 
       excisionResults.some(r => {
-        const AisOrCancerCodes = ['ECT.14006.6', 'ECT.14006.10', 'ECT.14006.11'];
+        const AisOrCancerCodes = Object.keys(customExcisionCodes);
         return AisOrCancerCodes.includes(r.ID);
       });
     if ((colposcopyResults.length > 0) || (endocervicalCuretageResults.length > 0) || (excisionResults.length > 0 && ExcisionResultsShowAisOrCancer)) {

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -10,16 +10,62 @@ describe('translateResponse', () => {
   beforeEach(() => {
     patientData = JSON.parse(patientDataContent).patientData;
     customApiResponse = JSON.parse(resultContent);
-    translateResponse(customApiResponse, patientData);
   });
 
   describe('parse procedure data', () => {
     it('should include Cervix Excision procedure', function () {
+      translateResponse(customApiResponse, patientData);
       expect(patientData.length).to.be.greaterThan(2);
 
       const procedures = patientData.filter(pd => pd.resourceType === 'Procedure');
-      expect(procedures.length).to.be.greaterThan(0);
+      expect(procedures.length).to.be.greaterThan(1);
       expect(procedures.some(p => p.code.coding.some(coding => coding.code === '120038005'))).to.be.true;
+    });
+  });
+
+  describe('Parse excision results that are not AIS or histologic cancer', () => {
+    it('should ignore excision results that do not show AIS or histologic cancer', function () {
+      translateResponse(customApiResponse, patientData);
+      const diagnosticReports = patientData.filter(pd => pd.resourceType === 'DiagnosticReport');
+
+      expect(diagnosticReports.length).to.equal(1);
+      expect(diagnosticReports.some(p => p.code.coding.some(coding => coding.code === '65753-6'))).to.be.false;
+    });
+  });
+
+  describe('Parse AIS excision results', () => {
+    it('should map an AIS excision result to a biopsy', function () {
+      customApiResponse.Order[0].ExcisionResults = 
+        [
+          {
+            ID: 'ECT.14006.6',
+            Value: 'AIS'
+          }
+        ];
+      translateResponse(customApiResponse, patientData);
+      const diagnosticReports = patientData.filter(pd => pd.resourceType === 'DiagnosticReport');
+
+      expect(diagnosticReports.length).to.equal(1);
+      expect(diagnosticReports.some(p => p.code.coding.some(coding => coding.code === '65753-6'))).to.be.true;
+      expect(diagnosticReports.some(p => p.conclusionCode.some(cC => cC.coding.some(coding => coding.code === '254890008')))).to.be.true;
+    });
+  });
+
+  describe('Parse histologic cancer excision results', () => {
+    it('should map a histologic cancer excision result to a biopsy', function () {
+      customApiResponse.Order[0].ExcisionResults = 
+        [
+          {
+            ID: 'ECT.14006.11',
+            Value: 'Adenocarcinoma'
+          }
+        ];      
+      translateResponse(customApiResponse, patientData);
+      const diagnosticReports = patientData.filter(pd => pd.resourceType === 'DiagnosticReport');
+
+      expect(diagnosticReports.length).to.equal(1);
+      expect(diagnosticReports.some(p => p.code.coding.some(coding => coding.code === '65753-6'))).to.be.true;
+      expect(diagnosticReports.some(p => p.conclusionCode.some(cC => cC.coding.some(coding => coding.code === '363354003')))).to.be.true;
     });
   });
 });

--- a/test/translate-test.js
+++ b/test/translate-test.js
@@ -23,7 +23,7 @@ describe('translateResponse', () => {
     });
   });
 
-  describe('Parse excision results that are not AIS or histologic cancer', () => {
+  describe('parse excision results', () => {
     it('should ignore excision results that do not show AIS or histologic cancer', function () {
       translateResponse(customApiResponse, patientData);
       const diagnosticReports = patientData.filter(pd => pd.resourceType === 'DiagnosticReport');
@@ -31,9 +31,7 @@ describe('translateResponse', () => {
       expect(diagnosticReports.length).to.equal(1);
       expect(diagnosticReports.some(p => p.code.coding.some(coding => coding.code === '65753-6'))).to.be.false;
     });
-  });
 
-  describe('Parse AIS excision results', () => {
     it('should map an AIS excision result to a biopsy', function () {
       customApiResponse.Order[0].ExcisionResults = 
         [
@@ -49,9 +47,7 @@ describe('translateResponse', () => {
       expect(diagnosticReports.some(p => p.code.coding.some(coding => coding.code === '65753-6'))).to.be.true;
       expect(diagnosticReports.some(p => p.conclusionCode.some(cC => cC.coding.some(coding => coding.code === '254890008')))).to.be.true;
     });
-  });
 
-  describe('Parse histologic cancer excision results', () => {
     it('should map a histologic cancer excision result to a biopsy', function () {
       customApiResponse.Order[0].ExcisionResults = 
         [


### PR DESCRIPTION
This helps to address [CCSMCDS-4](https://jira.mitre.org/browse/CCSMCDS-4) and [CCSMCDS-29](https://jira.mitre.org/browse/CCSMCDS-29).

This PR maps AIS and Histologic Cancer excision results entered in the SmartForm to cervical biopsy Diagnostic Reports in our CDS. This is because both Jira tickets linked above require taking an action if both high-risk results are present at _any_ point in the patient record, even as the result of an excisional treatment.

Extra logic is added to make sure that mapping does not occur for other Excisional Treatment results, since our CDS should be ignoring these, and we do not want them accidentally included in our CDS as biopsies with a missing result code.

Testing is included to show that AIS and histologic cancer are properly mapped, and that other excision results are not mapped.