### PR TITLE
Refine Prefetch

### DIFF
--- a/config/apply/ccsm/prefetch.js
+++ b/config/apply/ccsm/prefetch.js
@@ -6,7 +6,7 @@ export const prefetch = {
   'MedicationRequest': 'MedicationRequest?patient={{context.patientId}}&status=active&intent=order',
   'ProcedureOrders': 'Procedure?patient={{context.patientId}}&category=103693007',
   'ProcedureSurgerical': 'Procedure?patient={{context.patientId}}&category=387713003',
-  'DiagnosticReport': 'DiagnosticReport?patient={{context.patientId}}&category=http://terminology.hl7.org/CodeSystem/v2-0074|LAB',
+  'DiagnosticReport': 'DiagnosticReport?patient={{context.patientId}}&category=LAB',
   'Encounter': 'Encounter/{{context.encounterId}}',
   'Immunization': 'Immunization?patient={{context.patientId}}&status=completed'
 };

--- a/config/apply/ccsm/prefetch.js
+++ b/config/apply/ccsm/prefetch.js
@@ -1,15 +1,12 @@
 export const prefetch = {
   'Patient': 'Patient/{{context.patientId}}',
-  'ObservationCore': 'Observation?patient={{context.patientId}}&category=core-characteristics',
-  'ObservationLab': 'Observation?patient={{context.patientId}}&category=laboratory',
-  'ObservationLabor': 'Observation?patient={{context.patientId}}&category=labor-delivery',
-  'ObservationObGyn': 'Observation?patient={{context.patientId}}&category=obstetrics-gynecology',
-  'ObservationSmart': 'Observation?patient={{context.patientId}}&category=smartdata',
-  'Condition': 'Condition?patient={{context.patientId}}',
+  'ConditionEncounterDiagnosis': 'Condition?patient={{context.patientId}}&category=encounter-diagnosis&clinical-status=active',
   'ConditionProblem': 'Condition?patient={{context.patientId}}&category=problem-list-item&clinical-status=active',
-  'MedicationRequest': 'MedicationRequest?patient={{context.patientId}}',
-  'Procedure': 'Procedure?patient={{context.patientId}}',
-  'DiagnosticReport': 'DiagnosticReport?patient={{context.patientId}}',
-  'Encounter': 'Encounter?patient={{context.patientId}}',
-  'Immunization': 'Immunization?patient={{context.patientId}}'
+  'ConditionMedicalHistory': 'Condition?patient={{context.patientId}}&category=medical-history&clinical-status=active',
+  'MedicationRequest': 'MedicationRequest?patient={{context.patientId}}&status=active&intent=order',
+  'ProcedureOrders': 'Procedure?patient={{context.patientId}}&category=103693007',
+  'ProcedureSurgerical': 'Procedure?patient={{context.patientId}}&category=387713003',
+  'DiagnosticReport': 'DiagnosticReport?patient={{context.patientId}}&category=http://terminology.hl7.org/CodeSystem/v2-0074|LAB',
+  'Encounter': 'Encounter/{{context.encounterId}}',
+  'Immunization': 'Immunization?patient={{context.patientId}}&status=completed'
 };


### PR DESCRIPTION
Refine prefetch parameters to only those needed by UPMC.

Using request parameters defined by https://fhir.epic.com/Specifications, as well as our knowledge of how data is being represented by UPMC as is evident from the UPMC [Epic Results](https://upmchs.sharepoint.com/:f:/r/sites/CDCMitreUPMCCollaboration/Shared%20Documents/General/testing/Epic%20Results?csf=1&web=1&e=Is4jwW) folder, I narrowed down the scope of our prefetch parameters to look for only those resources that our CDS could need.