### PR TITLE
Modify Prefetch by removing unused queries and filtering DiagnosticReports to only pap tracker results

### DIFF
--- a/config/apply/ccsm/prefetch.js
+++ b/config/apply/ccsm/prefetch.js
@@ -1,12 +1,9 @@
 export const prefetch = {
   'Patient': 'Patient/{{context.patientId}}',
-  'ConditionEncounterDiagnosis': 'Condition?patient={{context.patientId}}&category=encounter-diagnosis&clinical-status=active',
   'ConditionProblem': 'Condition?patient={{context.patientId}}&category=problem-list-item&clinical-status=active',
   'ConditionMedicalHistory': 'Condition?patient={{context.patientId}}&category=medical-history&clinical-status=active',
-  'MedicationRequest': 'MedicationRequest?patient={{context.patientId}}&status=active&intent=order',
   'ProcedureOrders': 'Procedure?patient={{context.patientId}}&category=103693007',
   'ProcedureSurgerical': 'Procedure?patient={{context.patientId}}&category=387713003',
-  'DiagnosticReport': 'DiagnosticReport?patient={{context.patientId}}&category=LAB',
+  'DiagnosticReport': 'DiagnosticReport?patient={{context.patientId}}&category=CYTOPATH',
   'Encounter': 'Encounter/{{context.encounterId}}',
-  'Immunization': 'Immunization?patient={{context.patientId}}&status=completed'
 };


### PR DESCRIPTION
The following modifications are made to the prefetch queries:
- remove ConditionEncounterDiagnosis
- remove MedicationRequest
- remove Immunization
- filter DiagnosticReport by category=CYTOPATH

This way, we are removing queries for data that is not used by our CDS, and refining the DiagnosticReport query to only fetch results that were entered via the pap tracking smart form.