### PR TITLE
Add more granular console.time statements

### DIFF
--- a/config/apply/ccsm/collapse.js
+++ b/config/apply/ccsm/collapse.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { marked } from 'marked';
 import { getSources } from './formatCards.js';
 
@@ -34,6 +35,7 @@ export function collapseIntoOne(cards, useHtml=false) {
       riskTable
     } = details;
     let sources = getSources(decisionAids[0]?.extension?.documentation.filter(d => d.label === recommendationGroup));
+    console.log('Sources:');
     console.log(sources);
     // Generate the markdown details
     let markdown =

--- a/config/apply/ccsm/translate.js
+++ b/config/apply/ccsm/translate.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ScreeningAndManagementTestType } from 'ccsm-cds-with-tests/fhir/ValueSet/ScreeningAndManagementTestType.js';
 import { CervicalCytologyResult } from 'ccsm-cds-with-tests/fhir/ValueSet/CervicalCytologyResult.js';
 import { HpvTestResult } from 'ccsm-cds-with-tests/fhir/ValueSet/HpvTestResult.js';

--- a/routes/cds-services.js
+++ b/routes/cds-services.js
@@ -239,6 +239,7 @@ async function call(req, res, next) {
       if (patientId) { searchURL = searchURL.split('{{context.patientId}}').join(patientId); }
       console.log('Request context: ', req.body.context);
       console.log('searchURL ', searchURL);
+
       console.time('Custom API call');
       const result = await client.request(searchURL, { pageLimit: 0, flat: true });
       console.timeEnd('Custom API call');
@@ -287,6 +288,7 @@ async function call(req, res, next) {
     console.time('Apply operation');
     const [RequestGroup, ...otherResources] = await applyAndMerge(planDefinition, patientReference, resolver, aux);
     console.timeEnd('Apply operation');
+
     // If RequestGroup has actions, convert them to properly-formatted CDS Hooks cards
     if (RequestGroup?.action) {
       console.time('Format cards');
@@ -315,6 +317,7 @@ async function call(req, res, next) {
 
   } else { // Evaluate CQL expressions (not tied to any PlanDefinition)
     console.time('Evaluate CQL expressions not tied to any PlanDefinition');
+
     // Get the lib from the res.locals (thanks, middleware!)
     const lib = res.locals.library;
 


### PR DESCRIPTION
Add more granular `console.time()` statements, specifically around the CQL execution step, to pinpoint where timing bottlenecks exist.