### PR TITLE
Add type parameter to EpisodeOfCare Search query

### DIFF
--- a/config/apply/ccsm/prefetch.js
+++ b/config/apply/ccsm/prefetch.js
@@ -3,4 +3,5 @@ export const prefetch = {
   'Condition': 'Condition?patient={{context.patientId}}&category=problem-list-item,medical-history&clinical-status=active',
   'Procedure': 'Procedure?patient={{context.patientId}}&category=103693007,387713003',
   'Encounter': 'Encounter/{{context.encounterId}}',
+  'EpisodeOfCare': 'EpisodeOfCare?patient={{context.patientId}}&type=urn:oid:1.2.840.114350.1.13.88.2.7.2.726668|6,urn:oid:1.2.840.114350.1.13.88.3.7.2.726668|6',
 };


### PR DESCRIPTION
According to the [EpisodeOfCare.Search Epic API](https://fhir.epic.com/Sandbox?api=10157), EpisodeOfCare.type is a required parameter for the search query. These are the Episode of Care types that UPMC's Epic instance uses top represent a pregnancy, according to the attached screenshot:

![image](https://github.com/ccsm-cds-tools/ccsm-cds-service/assets/51176978/18117d75-a352-4f3a-b90d-272c8b2884f6)
