### PR TITLE
Remove Non-prod EpisodeOfCare type from Prefetch Search Query

### DIFF
--- a/config/apply/ccsm/prefetch.js
+++ b/config/apply/ccsm/prefetch.js
@@ -1,5 +1,5 @@
 export const prefetch = {
   'Patient': 'Patient/{{context.patientId}}',
   'Encounter': 'Encounter/{{context.encounterId}}',
-  'EpisodeOfCare': 'EpisodeOfCare?patient={{context.patientId}}&type=urn:oid:1.2.840.114350.1.13.88.2.7.2.726668|6,urn:oid:1.2.840.114350.1.13.88.3.7.2.726668|6',
+  'EpisodeOfCare': 'EpisodeOfCare?patient={{context.patientId}}&type=urn:oid:1.2.840.114350.1.13.88.2.7.2.726668|6',
 };


### PR DESCRIPTION
Remove non-production EpisodeOfCare type from prefetch search query, since only one type is allowed to be searched.