### PR TITLE
Release 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,8 @@ Update `ccsm-cds-with-tests` dependency to 0.4.14
 ## 3.0.3
 
 Update `ccsm-cds-with-tests` dependency to 0.4.15
+
+## 3.0.4
+
+Begin work on re-formatting CDS Hooks cards (#36)
+Update `ccsm-cds-with-tests` dependency to 0.4.16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cql-exec-service",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cql-exec-service",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.2",
-        "ccsm-cds-with-tests": "^0.4.15",
+        "ccsm-cds-with-tests": "^0.4.16",
         "commander": "^2.20.3",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
@@ -5988,9 +5988,9 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/ccsm-cds-with-tests": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.15.tgz",
-      "integrity": "sha512-d0Ap6QK81e9VDvWhaIcDVb9B3jhWh5THf8NMl6kdw6aGzlUJjtAoTIwXGNx/QnaR8s28nTkDxvplQkj5dauAqg==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.16.tgz",
+      "integrity": "sha512-/b8wuh5TTueY4Xqr09hcM8Zt7XgIp8iGVgr8PY9tVxXTrc789Mqw+JjzPQm95lnmh5oMwX6e+06XTVJGW7h0fg==",
       "dependencies": {
         "cql-testing": "^2.5.3"
       }
@@ -21201,9 +21201,9 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "ccsm-cds-with-tests": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.15.tgz",
-      "integrity": "sha512-d0Ap6QK81e9VDvWhaIcDVb9B3jhWh5THf8NMl6kdw6aGzlUJjtAoTIwXGNx/QnaR8s28nTkDxvplQkj5dauAqg==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.16.tgz",
+      "integrity": "sha512-/b8wuh5TTueY4Xqr09hcM8Zt7XgIp8iGVgr8PY9tVxXTrc789Mqw+JjzPQm95lnmh5oMwX6e+06XTVJGW7h0fg==",
       "requires": {
         "cql-testing": "^2.5.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-exec-service",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A RESTful CQL execution service",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.2",
-    "ccsm-cds-with-tests": "^0.4.15",
+    "ccsm-cds-with-tests": "^0.4.16",
     "commander": "^2.20.3",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",


### PR DESCRIPTION
# Release 3.0.4
- Begin work on re-formatting CDS Hooks cards #36
- Bump ccsm-cds-with-tests to version 0.4.16

This PR bumps ccsm-cds-with-tests to version 0.4.16 and updates the ccsm-cds-service version number and changelog in preparation for release 3.0.4.