### PR TITLE
Add performance updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ Update `ccsm-cds-with-tests` dependency to 0.4.16
 ## 3.0.5
 
 Update bpa card spacing (#38)
+
+## 3.1.0
+
+Update CQL execution dependencies to leverage performance enhancements
+Update `ccsm-cds-with-tests` dependency to 0.4.19

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cors": "^2.8.5",
         "cql-exec-fhir": "github:ccsm-cds-tools/cql-exec-fhir#memoize-to-fhir-object",
         "cql-exec-vsac": "^2.0.1",
-        "cql-execution": "^3.0.1",
+        "cql-execution": "github:cqframework/cql-execution#cache_function_ref",
         "dayjs": "^1.11.10",
         "debug": "~2.6.0",
         "encender": "^0.7.1",
@@ -6742,9 +6742,8 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/cql-execution": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
-      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
+      "version": "3.1.0",
+      "resolved": "git+ssh://git@github.com/cqframework/cql-execution.git#bc0b6e403d6b11ea26ac1966d11cf1605039fe00",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -21794,9 +21793,8 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
-      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
+      "version": "git+ssh://git@github.com/cqframework/cql-execution.git#bc0b6e403d6b11ea26ac1966d11cf1605039fe00",
+      "from": "cql-execution@github:cqframework/cql-execution#cache_function_ref",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "cql-execution": "github:cqframework/cql-execution#cache_function_ref",
         "dayjs": "^1.11.10",
         "debug": "~2.6.0",
-        "encender": "^0.7.1",
+        "encender": "github:ccsm-cds-tools/encender#cql-execution",
         "express": "^4.17.3",
         "fhirclient": "^2.4.0",
         "helmet": "^4.6.0",
@@ -6946,9 +6946,9 @@
       }
     },
     "node_modules/cql-worker": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.7.tgz",
-      "integrity": "sha512-wSjavK9yyhaqa4VGO8QcTZJuw5lN7bk3kYscbTt9xHJdudczIY8rQS967eyBsTba1lGrjsN9uKAFAPqPd4RuoA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.8.tgz",
+      "integrity": "sha512-Gk6uSb5pGzWVRuFjTMf5pL+tkfHXfAHoyndoOo8440FwB0Zno9WFY+aPmnKBsv6UD1p2DvSMpQqK4P6LZ5f67g==",
       "dependencies": {
         "cql-exec-fhir": "^2.1.4",
         "cql-execution": "^3.0.1"
@@ -7304,11 +7304,10 @@
     },
     "node_modules/encender": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/encender/-/encender-0.7.1.tgz",
-      "integrity": "sha512-7w27zgCQ5zIaXdPIPfq/iwlaWgbw+gCPaIOFJsQL313Pf2sYmlDeUH8WHTtMSMVv4m+YpguYMVBFP7kAXw8ClQ==",
+      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#8239c48fe4716efa8ee7085a3e4c33a1031ae239",
       "dependencies": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
-        "cql-worker": "^1.1.7",
+        "cql-worker": "1.1.8",
         "semver": "^6.3.0"
       }
     },
@@ -21945,9 +21944,9 @@
       }
     },
     "cql-worker": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.7.tgz",
-      "integrity": "sha512-wSjavK9yyhaqa4VGO8QcTZJuw5lN7bk3kYscbTt9xHJdudczIY8rQS967eyBsTba1lGrjsN9uKAFAPqPd4RuoA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/cql-worker/-/cql-worker-1.1.8.tgz",
+      "integrity": "sha512-Gk6uSb5pGzWVRuFjTMf5pL+tkfHXfAHoyndoOo8440FwB0Zno9WFY+aPmnKBsv6UD1p2DvSMpQqK4P6LZ5f67g==",
       "requires": {
         "cql-exec-fhir": "^2.1.4",
         "cql-execution": "^3.0.1"
@@ -22234,12 +22233,11 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encender": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/encender/-/encender-0.7.1.tgz",
-      "integrity": "sha512-7w27zgCQ5zIaXdPIPfq/iwlaWgbw+gCPaIOFJsQL313Pf2sYmlDeUH8WHTtMSMVv4m+YpguYMVBFP7kAXw8ClQ==",
+      "version": "git+ssh://git@github.com/ccsm-cds-tools/encender.git#8239c48fe4716efa8ee7085a3e4c33a1031ae239",
+      "from": "encender@github:ccsm-cds-tools/encender#cql-execution",
       "requires": {
         "@asymmetrik/fhir-json-schema-validator": "^0.9.8",
-        "cql-worker": "^1.1.7",
+        "cql-worker": "1.1.8",
         "semver": "^6.3.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.2",
-        "ccsm-cds-with-tests": "^0.4.16",
+        "ccsm-cds-with-tests": "^0.4.19",
         "commander": "^2.20.3",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
@@ -5988,9 +5988,9 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/ccsm-cds-with-tests": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.16.tgz",
-      "integrity": "sha512-/b8wuh5TTueY4Xqr09hcM8Zt7XgIp8iGVgr8PY9tVxXTrc789Mqw+JjzPQm95lnmh5oMwX6e+06XTVJGW7h0fg==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.19.tgz",
+      "integrity": "sha512-AxWNdFqVonzOI0o6WB0+O7DZrR8hh29szThDmsWj+iePLb4pX3nTNQ7OX4M43GqknXHhDHJvHS2OAaQ5UlylPQ==",
       "dependencies": {
         "cql-testing": "^2.5.3"
       }
@@ -21201,9 +21201,9 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "ccsm-cds-with-tests": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.16.tgz",
-      "integrity": "sha512-/b8wuh5TTueY4Xqr09hcM8Zt7XgIp8iGVgr8PY9tVxXTrc789Mqw+JjzPQm95lnmh5oMwX6e+06XTVJGW7h0fg==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/ccsm-cds-with-tests/-/ccsm-cds-with-tests-0.4.19.tgz",
+      "integrity": "sha512-AxWNdFqVonzOI0o6WB0+O7DZrR8hh29szThDmsWj+iePLb4pX3nTNQ7OX4M43GqknXHhDHJvHS2OAaQ5UlylPQ==",
       "requires": {
         "cql-testing": "^2.5.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cql-exec-service",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cql-exec-service",
-      "version": "3.0.5",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "commander": "^2.20.3",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
-        "cql-exec-fhir": "^2.1.4",
+        "cql-exec-fhir": "github:ccsm-cds-tools/cql-exec-fhir#memoize-to-fhir-object",
         "cql-exec-vsac": "^2.0.1",
         "cql-execution": "^3.0.1",
         "dayjs": "^1.11.10",
@@ -6698,8 +6698,7 @@
     },
     "node_modules/cql-exec-fhir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.5.tgz",
-      "integrity": "sha512-rNseLFJ2IVAtQQqsa4hb6uPFzD1EJBi0Hs4yPZNPqeCuNEUfqvO4dldJ7Edl8IcGMbIrWoKy17dLW5KBKzrSpw==",
+      "resolved": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#d6188beea6e17163943a17b2a592b57a780196de",
       "dependencies": {
         "xml2js": "^0.5.0"
       },
@@ -21762,9 +21761,8 @@
       }
     },
     "cql-exec-fhir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.5.tgz",
-      "integrity": "sha512-rNseLFJ2IVAtQQqsa4hb6uPFzD1EJBi0Hs4yPZNPqeCuNEUfqvO4dldJ7Edl8IcGMbIrWoKy17dLW5KBKzrSpw==",
+      "version": "git+ssh://git@github.com/ccsm-cds-tools/cql-exec-fhir.git#d6188beea6e17163943a17b2a592b57a780196de",
+      "from": "cql-exec-fhir@github:ccsm-cds-tools/cql-exec-fhir#memoize-to-fhir-object",
       "requires": {
         "xml2js": "^0.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cql-execution": "github:cqframework/cql-execution#cache_function_ref",
     "dayjs": "^1.11.10",
     "debug": "~2.6.0",
-    "encender": "^0.7.1",
+    "encender": "github:ccsm-cds-tools/encender#cql-execution",
     "express": "^4.17.3",
     "fhirclient": "^2.4.0",
     "helmet": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "commander": "^2.20.3",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
-    "cql-exec-fhir": "^2.1.4",
+    "cql-exec-fhir": "github:ccsm-cds-tools/cql-exec-fhir#memoize-to-fhir-object",
     "cql-exec-vsac": "^2.0.1",
     "cql-execution": "^3.0.1",
     "dayjs": "^1.11.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-exec-service",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "description": "A RESTful CQL execution service",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cors": "^2.8.5",
     "cql-exec-fhir": "github:ccsm-cds-tools/cql-exec-fhir#memoize-to-fhir-object",
     "cql-exec-vsac": "^2.0.1",
-    "cql-execution": "^3.0.1",
+    "cql-execution": "github:cqframework/cql-execution#cache_function_ref",
     "dayjs": "^1.11.10",
     "debug": "~2.6.0",
     "encender": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.2",
-    "ccsm-cds-with-tests": "^0.4.16",
+    "ccsm-cds-with-tests": "^0.4.19",
     "commander": "^2.20.3",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",


### PR DESCRIPTION
- Upgrade CQL execution dependencies to leverage performance updates:
   - cql-exec-fhir
   - cql-execution
   - encender
- Update ccsm-cds-with-tests dependency to 0.4.19